### PR TITLE
Fixed encoding error in subset tool in Windows

### DIFF
--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -2902,7 +2902,7 @@ def main(args=None):
             text += g[7:]
             continue
         if g.startswith('--text-file='):
-            text += open(g[12:]).read().replace('\n', '')
+            text += open(g[12:], encoding='utf-8').read().replace('\n', '')
             continue
         if g.startswith('--unicodes='):
             if g[11:] == '*':


### PR DESCRIPTION
Fixed encoding error in subset tool in Windows which system default codepage isn't 65001.
For Example: 
When windows default codepage is 936, the command like 'pyftsubset myfont.ttf --text-file=mytextfile.txt' will throw an exception.